### PR TITLE
FILMDOMS #80 메인 페이지 CLS 이슈를 해결합니다

### DIFF
--- a/components/common/Loading/Loading.tsx
+++ b/components/common/Loading/Loading.tsx
@@ -1,19 +1,40 @@
 import styled from '@emotion/styled'
 import FilmDomsLoading from '@svgs/common/FilmDomsLoading.svg'
+import RenderIf from '../RenderIf'
 interface Props {
   width?: string
   height?: string
+  empty?: boolean
+  iconSize?: 'sm' | 'md' | 'lg'
 }
 
-const Loading = ({ width, height }: Props) => {
+const size = {
+  sm: '2rem',
+  md: '4rem',
+  lg: '8rem',
+}
+
+const Loading = ({ width, height, empty = false, iconSize = 'md' }: Props) => {
   return (
     <LoadingWrapper width={width} height={height}>
-      <FilmDomsLoading />
+      <RenderIf
+        condition={!empty}
+        render={
+          <IconBox iconSize={iconSize}>
+            <FilmDomsLoading />
+          </IconBox>
+        }
+      />
     </LoadingWrapper>
   )
 }
 
 export default Loading
+
+const IconBox = styled.div<Required<Pick<Props, 'iconSize'>>>`
+  width: ${({ iconSize }) => size[iconSize]};
+  height: ${({ iconSize }) => size[iconSize]};
+`
 
 export const LoadingWrapper = styled.div<{
   width?: string

--- a/components/views/Home/Banner/BannerContainer.tsx
+++ b/components/views/Home/Banner/BannerContainer.tsx
@@ -1,7 +1,13 @@
+import { Suspense } from 'react'
 import Banner from './Banner'
+import { Loading } from '@/components/common'
 
 const BannerContainer = () => {
-  return <Banner />
+  return (
+    <Suspense fallback={<Loading width="100%" height="512px" />}>
+      <Banner />
+    </Suspense>
+  )
 }
 
 export default BannerContainer

--- a/components/views/Home/Banner/Slider/SliderWrapper/SliderWrapper.tsx
+++ b/components/views/Home/Banner/Slider/SliderWrapper/SliderWrapper.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image'
 import { flexCenter, mediaQuery } from '@/styles/emotion'
 import styled from '@emotion/styled'
 
-function SliderWrapper({ banners }: { banners?: Banner[] }) {
+function SliderWrapper({ banners }: { banners: Banner[] }) {
   return (
     <SliderOutsideAlign>
       <Swiper
@@ -22,7 +22,7 @@ function SliderWrapper({ banners }: { banners?: Banner[] }) {
         pagination={{ clickable: true }}
         style={{ position: 'relative' }}
       >
-        {banners?.map(({ id, type, title, subtitle, image }: Banner) => (
+        {banners.map(({ id, type, title, subtitle, image }: Banner) => (
           <SwiperSlide key={id}>
             <Image src={image} alt={title} width={1280} height={440} priority />
             <TextArea>

--- a/components/views/Home/Community/CommunityContainer.tsx
+++ b/components/views/Home/Community/CommunityContainer.tsx
@@ -8,7 +8,7 @@ import RecentContainer from './Recent'
 const CommunityContainer = () => {
   return (
     <Section>
-      <Suspense fallback={<Loading />}>
+      <Suspense fallback={<Loading width="1280px" height="392px" />}>
         <RecentContainer />
         <MovieReviewContainer />
       </Suspense>

--- a/components/views/Home/Critic/CriticContainer.tsx
+++ b/components/views/Home/Critic/CriticContainer.tsx
@@ -1,5 +1,10 @@
 import { ArrowRight } from '@/assets/svgs/common'
-import { Button, ResetErrorBoundary, Section } from '@/components/common'
+import {
+  Button,
+  Loading,
+  ResetErrorBoundary,
+  Section,
+} from '@/components/common'
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { Suspense } from 'react'
@@ -23,7 +28,7 @@ const CriticContainer = () => {
       />
       <SectionBody>
         <ResetErrorBoundary fallback={<div>에러...</div>}>
-          <Suspense fallback={<div>로딩...</div>}>
+          <Suspense fallback={<Loading width="100%" height="960px" />}>
             <Critics />
           </Suspense>
         </ResetErrorBoundary>

--- a/components/views/Home/Notice/NoticeContainer.tsx
+++ b/components/views/Home/Notice/NoticeContainer.tsx
@@ -1,5 +1,10 @@
 import { ArrowRight } from '@svgs/common'
-import { Button, ResetErrorBoundary, Section } from '@/components/common'
+import {
+  Button,
+  Loading,
+  ResetErrorBoundary,
+  Section,
+} from '@/components/common'
 import { css } from '@emotion/react'
 import { useRouter } from 'next/router'
 import React, { Suspense } from 'react'
@@ -19,7 +24,7 @@ const NoticeContainer = () => {
       />
       <Section.Body css={SectionBody}>
         <ResetErrorBoundary fallback={<div>에러...</div>}>
-          <Suspense fallback={<div>로딩...</div>}>
+          <Suspense fallback={<Loading width="100%" height="611px" />}>
             <Notices />
           </Suspense>
         </ResetErrorBoundary>

--- a/services/banner/queries.ts
+++ b/services/banner/queries.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query'
+import { useSuspendedQuery } from '@/hooks'
 import queryKeys from '../queryKeys'
 import { getBanners } from './apis'
 
 export const useFetchBanners = () => {
-  return useQuery(queryKeys.banner, getBanners)
+  return useSuspendedQuery(queryKeys.banner, getBanners)
 }


### PR DESCRIPTION
<작업 내용>
- 메인 페이지 로딩 컴포넌트의 크기를 지정합니다.
- banner fetch를 suspense로 구성합니다
- Loading 컴포넌트의 props을 추가합니다.
- - iconSize: 'sm' | 'md' | 'lg' 를 받으며 로딩 아이콘 사이즈를 지정합니다. default: 'md'
- - empty: 로딩 아이콘을 제외합니다. default: false
- - width, height: 기존에는 아이콘 Wrapper의 크기를 받았으나 현재는 로딩 전체 Wrapper의 크기를 받습니다.

<첨부>
- 아래는 msw delay를 각각 2s, 1s로 세팅 후 테스트한 결과입니다.
- before
![before_CLS](https://user-images.githubusercontent.com/84620459/231819704-d59d548b-bd23-475b-9e65-5b87e5dbe850.gif)

- after
![after_CLS](https://user-images.githubusercontent.com/84620459/231819632-e140e636-5585-4290-a3cf-e90f0924ad11.gif)

<관련된 이슈, 커밋, PR>
- ISSUE #80 
