### PR TITLE
FILMDOMS #102 회원가입 페이지의 디자인을 수정합니다

### DIFF
--- a/components/views/Auth/SignUp/SignUpForm/SignUpForm.tsx
+++ b/components/views/Auth/SignUp/SignUpForm/SignUpForm.tsx
@@ -283,22 +283,27 @@ const SignUpForm = () => {
             }
           />
         </Group>
-        <Divider color={colors.grey[100]} size={1} />
-        <Group>
-          <InputBox>
-            <Label />
-            <Input
-              width="sm"
-              {...register('emailAuthCode')}
-              type="password"
-              required
-              autoComplete="off"
-            />
-            <Button type="button" onClick={handleEmailAuthCodeCheck}>
-              인증번호 확인
-            </Button>
-          </InputBox>
-        </Group>
+        <RenderIf
+          condition={!!serverInput.email}
+          render={
+            <Flex gap="1rem" padding="0px 0px 16px 0px">
+              <InputBox>
+                <Label />
+                <Input
+                  width="sm"
+                  {...register('emailAuthCode')}
+                  type="password"
+                  required
+                  autoComplete="off"
+                />
+                <Spacing />
+                <Button type="button" onClick={handleEmailAuthCodeCheck}>
+                  인증번호 확인
+                </Button>
+              </InputBox>
+            </Flex>
+          }
+        />
         <Divider color={colors.grey[100]} size={1} />
         <Group>
           <InputBox>
@@ -438,14 +443,22 @@ const SignUpForm = () => {
   )
 }
 
+const Spacing = styled.div<{ size?: CSSProperties['width'] }>`
+  width: ${({ size = '1rem' }) => size};
+`
+
 const Empty = styled.div`
   width: 160px;
   height: 10px;
 `
 
-const Flex = styled.div<{ gap?: CSSProperties['gap'] }>`
+const Flex = styled.div<{
+  gap?: CSSProperties['gap']
+  padding?: CSSProperties['padding']
+}>`
   display: flex;
   gap: ${({ gap }) => gap};
+  padding: ${({ padding }) => padding};
 `
 
 const SignUpButton = styled.button`
@@ -520,7 +533,7 @@ const Group = styled.div`
   ${flex({ direction: 'column', justify: 'center' })}
   gap: 1rem;
   min-height: 80px;
-  padding: 16px 0;
+  padding: '16px 0px';
 `
 
 const Box = styled.div`


### PR DESCRIPTION
<작업 내용>
- 이메일과 인증번호 확인 버튼 간 `Divider` 제거
- 이메일 발송이 정상적으로 동작하면 인증번호 확인 버튼을 보여줍니다.
- 입력란의 `placeholder`를 수정합니다.
- - 비밀번호
- - 닉네임

<첨부>
- [x] 빌드 체크
- 작업 결과
![result](https://github.com/FILMDOM-s/film-doms/assets/84620459/01152dad-7b35-458d-b17c-112ecc34016b)

<관련된 이슈, 커밋, PR>
- ISSUE #102 
