### PR TITLE
FILMDOMS #140 비로그인 시, 헤더 유저 아이콘 렌더링 이슈를 해결합니다

### DIFF
--- a/components/views/Layout/Header/Avatar/Avatar.tsx
+++ b/components/views/Layout/Header/Avatar/Avatar.tsx
@@ -1,35 +1,35 @@
-import { Person } from '@svgs/common'
-import { useModal } from '@/hooks/useModal'
+import { defaultProfile } from '@/assets/images/common'
 import { SignIn } from '@/components/views/Auth'
+import { useModal } from '@/hooks/useModal'
 import { useFetchUserInfo } from '@/services/myPage'
-import Image from 'next/image'
 import { getImageSrcByUuid } from '@/utils'
+import { Person } from '@svgs/common'
+import Image from 'next/image'
 import Link from 'next/link'
+import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 
 const Avatar = () => {
-  const {
-    data: { profileImage },
-    error,
-  } = useFetchUserInfo()
-
-  if (error) {
-    return <GuestUser />
-  }
-
-  return <LoginUser image={getImageSrcByUuid(profileImage.uuidFileName)} />
+  return (
+    <ErrorBoundary fallback={<GuestUser />}>
+      <Suspense fallback={<GuestUser />}>
+        <LoginUser />
+      </Suspense>
+    </ErrorBoundary>
+  )
 }
 
 export default Avatar
 
-interface LoginUserProps {
-  image: string
-}
+const LoginUser = () => {
+  const {
+    data: { profileImage },
+  } = useFetchUserInfo()
 
-const LoginUser = ({ image }: LoginUserProps) => {
   return (
     <Link href="/mypage">
       <Image
-        src={image}
+        src={getImageSrcByUuid(profileImage?.uuidFileName ?? defaultProfile)}
         alt="user-image"
         fill
         style={{ borderRadius: '50%' }}

--- a/components/views/Layout/Header/Header.tsx
+++ b/components/views/Layout/Header/Header.tsx
@@ -2,7 +2,7 @@ import { mediaQuery } from '@/styles/emotion'
 import styled from '@emotion/styled'
 import { flexCenter } from '@/styles/emotion'
 import SideNav from '../SideNav'
-import { Suspense, useState } from 'react'
+import { useState } from 'react'
 import * as Svgs from '@svgs/common'
 import NavContainer from '../../Home/Nav/NavContainer'
 import Link from 'next/link'
@@ -35,9 +35,7 @@ const Header = () => {
             </IconWrapper>
           </IconMutableWrapper>
           <IconWrapper>
-            <Suspense fallback={<Svgs.Person fill="#FFFFFF" />}>
-              <Avatar />
-            </Suspense>
+            <Avatar />
           </IconWrapper>
         </RightSideWrapper>
       </HeaderInner>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,6 +23,7 @@ export default function App({
       queries: {
         refetchOnWindowFocus: false,
         staleTime: Infinity,
+        retry: 0,
       },
     },
   })


### PR DESCRIPTION
<작업 내용>
- 비로그인 시, 헤더 유저 아이콘 렌더링 이슈를 해결합니다

<첨부>
- 해당 `url` 접속 후, 헤더 유저 아이콘 확인 및 클릭

<관련된 이슈, 커밋, PR>
- ISSUE #140 
