### PR TITLE
hotfix: 유저 프로필 조회 쿼리를 수정하고 사용하지 않는 쿼리를 제거합니다

### DIFF
--- a/components/views/MyPage/MyPageContainer.tsx
+++ b/components/views/MyPage/MyPageContainer.tsx
@@ -1,5 +1,5 @@
 import { RenderIf } from '@/components/common'
-import { useFetchSocialUserInfo, useFetchUserInfo } from '@/services/myPage'
+import { useFetchUserInfo } from '@/services/myPage'
 import { flexCenter, flexGap } from '@/styles/emotion'
 import styled from '@emotion/styled'
 import { Suspense } from 'react'
@@ -11,20 +11,16 @@ import FallbackLoading from '@/components/common/Loading/FallbackLoading'
 
 const MyPage = () => {
   const { data: userInfo } = useFetchUserInfo()
-  const { data: socialUserInfo } = useFetchSocialUserInfo()
 
-  if (!userInfo || !socialUserInfo) {
+  if (!userInfo) {
     return null
   }
 
-  const uuidFileName =
-    userInfo?.profileImage?.uuidFileName ||
-    socialUserInfo?.profileImage?.uuidFileName
-  const nickname = userInfo?.nickname || socialUserInfo?.nickname
-  const email = userInfo?.email || socialUserInfo?.email
-  const registeredAt = userInfo?.registeredAt || socialUserInfo?.registeredAt
-  const favoriteMovies =
-    userInfo?.favoriteMovies || socialUserInfo?.favoriteMovies
+  const uuidFileName = userInfo?.profileImage?.uuidFileName
+  const nickname = userInfo?.nickname
+  const email = userInfo?.email
+  const registeredAt = userInfo?.registeredAt
+  const favoriteMovies = userInfo?.favoriteMovies
 
   return (
     <Container>

--- a/services/myPage/apis.ts
+++ b/services/myPage/apis.ts
@@ -2,9 +2,7 @@ import { createParams } from '@/utils'
 import api from '../api'
 
 export const getUserInfo = async () => {
-  const result = await api.get<null, User.InfoDTO>(
-    `/api/v1/account/oauth/profile`
-  )
+  const result = await api.get<null, User.InfoDTO>(`/api/v1/account/profile`)
 
   if (result) {
     return result.result


### PR DESCRIPTION
<작업 내용>
- 일반 유저 프로필 조회 api 주소가 잘못되어 있는 것을 수정합니다. `oauth/profile` -> `profile`
- 마이페이지에서 사용하지 않는 소셜 사용자 프로필 조회 쿼리를 제거합니다.

<첨부>

<관련된 이슈, 커밋, PR>
- ISSUE #168 
